### PR TITLE
make validation error output more concise

### DIFF
--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -42,7 +42,7 @@ module Apivore
       end
 
       failure_message do |body|
-        @errors.join("\n")
+        @errors.map { |e| e.gsub(/^The property|in schema.*$/,'') }.join("\n")
       end
     end
   end


### PR DESCRIPTION
Example validation failure output:

```
2) the API path /services.json method get response 200 responds with the specified models
     Failure/Error: expect(response.body).to conform_to_the_documented_model_for(swagger, fragment)
        '#/0' did not contain a required property of 'serviceType' 
        '#/0' did not contain a required property of 'centreId' 
        '#/0' did not contain a required property of 'imageRef' 
        '#/0' did not contain a required property of 'shortTitle' 
        '#/0' did not contain a required property of 'longTitle' 
        '#/0/description' of type NilClass did not match the following type: string 
        '#/0/active' of type NilClass did not match the following type: boolean 
        '#/0' did not contain a required property of 'sortOrder' 
        '#/0' did not contain a required property of 'phoneNumber' 
        '#/0/email' of type NilClass did not match the following type: string 
        '#/0/url' of type NilClass did not match the following type: string 
        '#/0' contained undefined properties: 'service_type, centre_id, image_ref, short_title, long_title, sort_order, phone_number, _links' 
        '#/1' did not contain a required property of 'serviceType' 
        '#/1' did not contain a required property of 'centreId' 
        '#/1' did not contain a required property of 'imageRef' 
        '#/1' did not contain a required property of 'shortTitle' 
        '#/1' did not contain a required property of 'longTitle' 
        '#/1/description' of type NilClass did not match the following type: string 
        '#/1/active' of type NilClass did not match the following type: boolean 
        '#/1' did not contain a required property of 'sortOrder' 
        '#/1' did not contain a required property of 'phoneNumber' 
        '#/1/email' of type NilClass did not match the following type: string 
        '#/1/url' of type NilClass did not match the following type: string 
        '#/1' contained undefined properties: 'service_type, centre_id, image_ref, short_title, long_title, sort_order, phone_number, _links' 
        '#/2' did not contain a required property of 'serviceType' 
        '#/2' did not contain a required property of 'centreId' 
        '#/2' did not contain a required property of 'imageRef' 
        '#/2' did not contain a required property of 'shortTitle' 
        '#/2' did not contain a required property of 'longTitle' 
        '#/2/description' of type NilClass did not match the following type: string 
        '#/2/active' of type NilClass did not match the following type: boolean 
        '#/2' did not contain a required property of 'sortOrder' 
        '#/2' did not contain a required property of 'phoneNumber' 
        '#/2/email' of type NilClass did not match the following type: string 
        '#/2/url' of type NilClass did not match the following type: string 
        '#/2' contained undefined properties: 'service_type, centre_id, image_ref, short_title, long_title, sort_order, phone_number, _links' 
     # /Users/charles/westfield/apivore/lib/apivore/rspec_builder.rb:66:in `block (3 levels) in validate'
```
