### PR TITLE
refactor modifications to swagger 2.0 schema

### DIFF
--- a/data/swagger_2.0_schema.json
+++ b/data/swagger_2.0_schema.json
@@ -77,22 +77,6 @@
     }
   },
   "definitions": {
-    "positiveInteger": {
-            "type": "integer",
-            "minimum": 0
-    },
-     "positiveIntegerDefault0": {
-            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
-    },
-    "stringArray": {
-            "type": "array",
-            "items": { "type": "string" },
-            "minItems": 1,
-            "uniqueItems": true
-    },
-    "simpleTypes": {
-            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
-    },
     "info": {
       "type": "object",
       "description": "General information about the API.",
@@ -908,50 +892,46 @@
           "type": "string"
         },
         "title": {
-          "type": "string" 
+          "$ref": "#/definitions/title"
         },
         "description": {
-          "type": "string" 
+          "$ref": "#/definitions/description"
         },
-        "default": { },
+        "default": {
+          "$ref": "#/definitions/default"
+        },
         "multipleOf": {
-           "type": "number",
-           "minimum": 0,
-           "exclusiveMinimum": true 
+          "$ref": "#/definitions/multipleOf"
         },
         "maximum": {
-          "type": "number"
+          "$ref": "#/definitions/maximum"
         },
         "exclusiveMaximum": {
-          "type": "boolean",
-          "default": false 
+          "$ref": "#/definitions/exclusiveMaximum"
         },
         "minimum": {
-          "type": "number" 
+          "$ref": "#/definitions/minimum"
         },
         "exclusiveMinimum": {
-          "type": "boolean",
-           "default": false 
+          "$ref": "#/definitions/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "#/definitions/positiveInteger"
+          "$ref": "#/definitions/maxLength"
         },
         "minLength": {
-          "$ref": "#/definitions/positiveIntegerDefault0"
+          "$ref": "#/definitions/minLength"
         },
         "pattern": {
-           "type": "string",
-           "format": "regex" 
+          "$ref": "#/definitions/pattern"
         },
         "maxItems": {
-          "$ref": "#/definitions/positiveInteger"
+          "$ref": "#/definitions/maxItems"
         },
         "minItems": {
-          "$ref": "#/definitions/positiveIntegerDefault0"
+          "$ref": "#/definitions/minItems"
         },
         "uniqueItems": {
-           "type": "boolean",
-           "default": false 
+          "$ref": "#/definitions/uniqueItems"
         },
         "maxProperties": {
           "$ref": "#/definitions/positiveInteger"
@@ -963,9 +943,7 @@
           "$ref": "#/definitions/stringArray"
         },
         "enum": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true 
+          "$ref": "#/definitions/enum"
         },
         "type": {
           "anyOf": [
@@ -1514,6 +1492,15 @@
           "type": "string"
         }
       }
+    },
+    "simpleTypes": {
+      "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1,
+      "uniqueItems": true
     }
   }
 }


### PR DESCRIPTION
To see the actual diff between the original swagger 2.0 schema doc and this latest version, look at this diff:

https://github.com/hornc/apivore/compare/5bfb7c91b10c3ad70e8b4eaa9f135d0f8c8d1016...de95d9519eac348ed3867e7fe5a86c4a0b19b22b#diff-7

The first set of changes I made just pasted the definitions from the external document in (which involved duplication). This makes use of internal refs in a more sensible fashion.
