### PR TITLE
Disable strict mode of JSON::Validator

### DIFF
--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -37,7 +37,7 @@ module Apivore
     matcher :conform_to_the_documented_model_for do |swagger, fragment|
       match do |body|
         body = JSON.parse(body)
-        @errors = JSON::Validator.fully_validate(swagger, body, fragment: fragment, strict: true)
+        @errors = JSON::Validator.fully_validate(swagger, body, fragment: fragment, strict: false)
         @errors.empty?
       end
 


### PR DESCRIPTION
Strict mode treats all properties as required, and ignores the
`required` attribute specified in the schema. This behaviour makes it
impossible to have optional fields in the schema.

Using the `required` property in the schema allows you to specify which
other properties are required and which are optional.
