### PR TITLE
Add require 'rspec/mocks' to fix crash.

### DIFF
--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -1,6 +1,7 @@
 require 'apivore/rspec_matchers'
 require 'action_controller'
 require 'action_dispatch'
+require 'rspec/mocks'
 require 'hashie'
 
 module Apivore
@@ -8,7 +9,7 @@ module Apivore
     include Apivore::RspecMatchers
     include ActionDispatch::Integration
     include RSpec::Mocks::ExampleMethods
-    
+
     @@setups ||= {}
 
     def apivore_setup(path, method, response, &block)


### PR DESCRIPTION
Updating apivore in Movie Service caused an exception to be thrown when used. Tracked this down to a missing require in `rspec_builder.rb`. Assume it's only an issue when the gem isn't already loaded in the parent app.