### PR TITLE
Add support for swagger consistency checks

### DIFF
--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -59,7 +59,7 @@ module Apivore
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
         if @@master_swagger_uri
-          req = Net::HTTP.get(master_swagger_uri, "/swagger.json")
+          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json")
           master_swagger = JSON.parse(req)
           it { should be_consistent_with_swagger_definitions master_swagger }
           it { should be_consistent_with_swagger_paths master_swagger }

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -12,6 +12,8 @@ module Apivore
 
     @@setups ||= {}
 
+    @@master_swagger_uri = nil
+
     def apivore_setup(path, method, response, &block)
       @@setups[path + method + response] = block
     end
@@ -33,6 +35,10 @@ module Apivore
       path
     end
 
+    def apivore_check_swagger_is_consistent_with(uri)
+      @@master_swagger_uri = uri
+    end
+
     def apivore_swagger(swagger_path)
       session = ActionDispatch::Integration::Session.new(Rails.application)
       begin
@@ -52,6 +58,9 @@ module Apivore
         subject { body }
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
+        if @@master_swagger_uri
+          it { should be_consistent_with_master_swagger_docs @@master_swagger_uri }
+        end
       end
 
       swagger = apivore_swagger(swagger_path)

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -35,7 +35,7 @@ module Apivore
       path
     end
 
-    def be_consistent_with_swagger_at(uri)
+    def apivore_check_consistency_with_swagger_at(uri)
       @@master_swagger_uri = uri
     end
 
@@ -59,7 +59,10 @@ module Apivore
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
         if @@master_swagger_uri
-          it { should be_consistent_with_swagger @@master_swagger_uri }
+          req = Net::HTTP.get(master_swagger_uri, "/swagger.json")
+          master_swagger = JSON.parse(req)
+          it { should be_consistent_with_swagger_definitions master_swagger }
+          it { should be_consistent_with_swagger_paths master_swagger }
         end
       end
 

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -35,7 +35,7 @@ module Apivore
       path
     end
 
-    def apivore_check_swagger_is_consistent_with(uri)
+    def be_consistent_with_swagger_at(uri)
       @@master_swagger_uri = uri
     end
 
@@ -59,7 +59,7 @@ module Apivore
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
         if @@master_swagger_uri
-          it { should be_consistent_with_master_swagger_docs @@master_swagger_uri }
+          it { should be_consistent_with_swagger @@master_swagger_uri }
         end
       end
 

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -62,7 +62,9 @@ module Apivore
           req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json")
           master_swagger = JSON.parse(req)
           it { should be_consistent_with_swagger_definitions master_swagger }
-          it { should be_consistent_with_swagger_paths master_swagger }
+          # This causes problems for migrations fixing the above test
+          # Once those migrations are complete, this should be enabled
+          xit { should be_consistent_with_swagger_paths master_swagger }
         end
       end
 

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -35,7 +35,7 @@ module Apivore
       end
     end
 
-    matcher :be_consistent_with_swagger do |master_swagger_uri|
+    matcher :be_consistent_with_swagger_definitions do |master_swagger|
 
       attr_reader :actual, :expected
 
@@ -45,8 +45,26 @@ module Apivore
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]
         our_definitions = our_swagger["definitions"]
-        @expected = master_definitions.slice(*our_definitions.keys)
-        @actual = our_definitions.slice(*master_definitions.keys)
+        master_definitions_segment = master_definitions.slice(*our_definitions.keys)
+        @actual = master_definitions_segment
+        @expected = our_definitions
+        @actual == @expected
+      end
+
+      diffable
+    end
+
+    matcher :be_consistent_with_swagger_paths do |master_swagger|
+
+      attr_reader :actual, :expected
+
+      match do |body|
+        our_swagger = JSON.parse(body)
+        master_paths = master_swagger["paths"]
+        our_paths = our_swagger["paths"]
+        master_paths_segment = master_paths.slice(*our_paths.keys)
+        @actual = master_paths_segment
+        @expected = our_paths
         @actual == @expected
       end
 

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -34,28 +34,23 @@ module Apivore
       end
     end
 
-    matcher :be_consistent_with_master_swagger_docs do |master_swagger_uri|
+    matcher :be_consistent_with_swagger do |master_swagger_uri|
+
+      attr_reader :actual, :expected
+
       match do |body|
-        @errors = []
         req = Faraday.new(master_swagger_uri).get("swagger.json")
         master_swagger = JSON.parse(req.body)
         our_swagger = JSON.parse(body)
-        master_paths = master_swagger["paths"]
-        our_paths = our_swagger["paths"]
-        master_paths_segment = master_paths.slice(*our_paths.keys)
-        expect(master_paths_segment).to eq(our_paths)
         master_definitions = master_swagger["definitions"]
         our_definitions = our_swagger["definitions"]
         master_definitions_segment = master_definitions.slice(*our_definitions.keys)
-        # should fail here
-        # TODO, better error messages!
-        expect(master_definitions_segment).to eq(our_definitions)
-        @errors.empty?
+        @actual = master_definitions_segment
+        @expected = our_definitions
+        @actual == @expected
       end
 
-      failure_message do
-        @errors.join("\n")
-      end
+      diffable
     end
 
     matcher :conform_to_the_documented_model_for do |swagger, fragment|

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -1,5 +1,6 @@
 require 'json-schema'
 require 'rspec/expectations'
+require 'net/http'
 
 module Apivore
   module RspecMatchers
@@ -39,7 +40,7 @@ module Apivore
       attr_reader :actual, :expected
 
       match do |body|
-        req = Faraday.new(master_swagger_uri).get("swagger.json")
+        req = Net::HTTP.get(master_swagger_uri, "swagger.json")
         master_swagger = JSON.parse(req.body)
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -34,6 +34,30 @@ module Apivore
       end
     end
 
+    matcher :be_consistent_with_master_swagger_docs do |master_swagger_uri|
+      match do |body|
+        @errors = []
+        req = Faraday.new(master_swagger_uri).get("swagger.json")
+        master_swagger = JSON.parse(req.body)
+        our_swagger = JSON.parse(body)
+        master_paths = master_swagger["paths"]
+        our_paths = our_swagger["paths"]
+        master_paths_segment = master_paths.slice(*our_paths.keys)
+        expect(master_paths_segment).to eq(our_paths)
+        master_definitions = master_swagger["definitions"]
+        our_definitions = our_swagger["definitions"]
+        master_definitions_segment = master_definitions.slice(*our_definitions.keys)
+        # should fail here
+        # TODO, better error messages!
+        expect(master_definitions_segment).to eq(our_definitions)
+        @errors.empty?
+      end
+
+      failure_message do
+        @errors.join("\n")
+      end
+    end
+
     matcher :conform_to_the_documented_model_for do |swagger, fragment|
       match do |body|
         body = JSON.parse(body)

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -40,8 +40,6 @@ module Apivore
       attr_reader :actual, :expected
 
       match do |body|
-        req = Net::HTTP.get(master_swagger_uri, "/swagger.json")
-        master_swagger = JSON.parse(req)
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]
         our_definitions = our_swagger["definitions"]

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -45,9 +45,8 @@ module Apivore
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]
         our_definitions = our_swagger["definitions"]
-        master_definitions_segment = master_definitions.slice(*our_definitions.keys)
-        @actual = master_definitions_segment
-        @expected = our_definitions
+        @expected = master_definitions.slice(*our_definitions.keys)
+        @actual = our_definitions.slice(*master_definitions.keys)
         @actual == @expected
       end
 

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -41,7 +41,7 @@ module Apivore
 
       match do |body|
         req = Net::HTTP.get(master_swagger_uri, "/swagger.json")
-        master_swagger = JSON.parse(req.body)
+        master_swagger = JSON.parse(req)
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]
         our_definitions = our_swagger["definitions"]

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -43,9 +43,8 @@ module Apivore
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]
         our_definitions = our_swagger["definitions"]
-        master_definitions_segment = master_definitions.slice(*our_definitions.keys)
-        @actual = master_definitions_segment
-        @expected = our_definitions
+        @actual = our_definitions.slice(*master_definitions.keys)
+        @expected = master_definitions.slice(*our_definitions.keys)
         @actual == @expected
       end
 
@@ -60,9 +59,8 @@ module Apivore
         our_swagger = JSON.parse(body)
         master_paths = master_swagger["paths"]
         our_paths = our_swagger["paths"]
-        master_paths_segment = master_paths.slice(*our_paths.keys)
-        @actual = master_paths_segment
-        @expected = our_paths
+        @actual = our_paths.slice(*master_paths.keys)
+        @expected = master_paths.slice(*our_paths.keys)
         @actual == @expected
       end
 

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -40,7 +40,7 @@ module Apivore
       attr_reader :actual, :expected
 
       match do |body|
-        req = Net::HTTP.get(master_swagger_uri, "swagger.json")
+        req = Net::HTTP.get(master_swagger_uri, "/swagger.json")
         master_swagger = JSON.parse(req.body)
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"]


### PR DESCRIPTION
Usage: 
```ruby
be_consistent_with_swagger_at "example.com"
```
It will then then look at http://example.com/swagger.json, and check to make sure there are no inconsistencies.