### PR TITLE
re-enable optional property test using additionalProperties

### DIFF
--- a/spec/data/07_missing_non-required_property.json
+++ b/spec/data/07_missing_non-required_property.json
@@ -57,13 +57,15 @@
           "type": "integer",
           "description": "Service id"
         },
-        "test_non-required": {
-          "type": ["string"],
-          "description": "Test property to see how apivore behaves when this field is not present in a response"
-        },
         "name": {
           "type": ["string", "null"],
           "description": "Service name"
+        }
+      },
+      "additionalProperties": {
+        "test_non-required": {
+          "type": ["string"],
+          "description": "Test property to see how apivore behaves when this field is not present in a response"
         }
       }
     }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -60,9 +60,9 @@ context "Apivore tests running against a mock API" do
     end
   end
 
-  describe "a reponse is missing a non-required property" do
+  describe "a reponse is missing an optional property" do
     it 'should pass validation' do
-      pending "needs a way to support non-required properties while still providing the functionality of json-schema's :strict validation (which catches undocumented properties)"
+      #pending "needs a way to support optional properties while still providing the functionality of json-schema's :strict validation (which catches undocumented properties)"
       stdout = `rspec spec/data/example_specs.rb --example 'missing non-required'`
       expect(stdout).to match(/0 failures/)
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -62,7 +62,6 @@ context "Apivore tests running against a mock API" do
 
   describe "a reponse is missing an optional property" do
     it 'should pass validation' do
-      #pending "needs a way to support optional properties while still providing the functionality of json-schema's :strict validation (which catches undocumented properties)"
       stdout = `rspec spec/data/example_specs.rb --example 'missing non-required'`
       expect(stdout).to match(/0 failures/)
     end


### PR DESCRIPTION
@chrisrbnelson I've re-enabled this test because optional properties do work with the additionalProperties field, as you said. It seems to be inherited from json-schema rather than from Swagger 2.0, which doesn't seem to say anything about it specifically.  The test swagger file that uses it, 07_missing_non-required_property.json, does pass the swagger 2.0 validation though, so it seems to all work nicely together. Easier than I thought, thanks for pointing me in the right direction!