### PR TITLE
Allow single service changes 1425962436

### DIFF
--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -59,7 +59,7 @@ module Apivore
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
         if @@master_swagger_uri
-          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json")
+          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json", 2999)
           master_swagger = JSON.parse(req)
           it { should be_consistent_with_swagger_definitions master_swagger }
           # This causes problems for migrations fixing the above test

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -35,7 +35,8 @@ module Apivore
       path
     end
 
-    def apivore_check_consistency_with_swagger_at(uri)
+    def apivore_check_consistency_with_swagger_at(uri, current_service = nil)
+      @@current_service = current_service
       @@master_swagger_uri = uri
     end
 
@@ -61,10 +62,7 @@ module Apivore
         if @@master_swagger_uri
           req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json", 2999)
           master_swagger = JSON.parse(req)
-          it { should be_consistent_with_swagger_definitions master_swagger }
-          # This causes problems for migrations fixing the above test
-          # Once those migrations are complete, this should be enabled
-          xit { should be_consistent_with_swagger_paths master_swagger }
+          it { should be_consistent_with_swagger_definitions master_swagger, @@current_service }
         end
       end
 

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -60,7 +60,7 @@ module Apivore
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
         if @@master_swagger_uri
-          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json", 2999)
+          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json")
           master_swagger = JSON.parse(req)
           it { should be_consistent_with_swagger_definitions master_swagger, @@current_service }
         end

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -60,7 +60,7 @@ module Apivore
         it { should be_valid_swagger }
         it { should have_models_for_all_get_endpoints }
         if @@master_swagger_uri
-          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json")
+          req = Net::HTTP.get(@@master_swagger_uri, "/swagger.json", 2999)
           master_swagger = JSON.parse(req)
           it { should be_consistent_with_swagger_definitions master_swagger, @@current_service }
         end

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -60,7 +60,10 @@ module Apivore
 
       match do |body|
         our_swagger = JSON.parse(body)
-        master_paths = master_swagger["paths"]
+        master_paths = master_swagger["paths"].transform_values do |path|
+          # 'x-services' is added by api.westfield.io - services shouldn't need to define it
+          path.tap{|p|p.delete 'x-services'}
+        end
         our_paths = our_swagger["paths"]
         @actual = our_paths.slice(*master_paths.keys)
         @expected = master_paths.slice(*our_paths.keys)

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -44,7 +44,7 @@ module Apivore
         master_definitions = master_swagger["definitions"].transform_values do |definition|
           # 'x-services' is added by api.westfield.io - services shouldn't need to define it
           if [current_service] == definition['x-services']
-            definition.tap{|d|d.delete 'x-services'}
+            nil
           else
             definition.tap{|d|d.delete 'x-services'}
           end

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -45,7 +45,8 @@ module Apivore
           if [current_service] == definition_fields['x-services']
             nil
           else
-            # 'x-services' is added by api.westfield.io - services shouldn't need to define it
+            # 'x-services' is added the aggregated swagger doc provided by api.westfield.io
+            # Individual services will not have a 'x-services' property so we need to remove it to allow the comparison to pass
             definition_fields.except 'x-services'
           end
         end.compact

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -41,7 +41,7 @@ module Apivore
 
       def cleaned_definitions(definitions, current_service)
         definitions.transform_values do |definition_fields|
-          # We ignore definitions that are owned exclusive by the current_service
+          # We ignore definitions that are owned exclusively by the current_service
           if [current_service] == definition_fields['x-services']
             nil
           else

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -46,7 +46,7 @@ module Apivore
             nil
           else
             # 'x-services' is added by api.westfield.io - services shouldn't need to define it
-            definition_fields.tap{|d|d.delete 'x-services'}
+            definition_fields.except 'x-services'
           end
         end.compact
       end

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -41,7 +41,10 @@ module Apivore
 
       match do |body|
         our_swagger = JSON.parse(body)
-        master_definitions = master_swagger["definitions"]
+        master_definitions = master_swagger["definitions"].transform_values do |definition|
+          # 'x-source' is added by api.westfield.io - services shouldn't need to define it
+          definition.tap{|d|d.delete 'x-source'}
+        end
         our_definitions = our_swagger["definitions"]
         @actual = our_definitions.slice(*master_definitions.keys)
         @expected = master_definitions.slice(*our_definitions.keys)

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -45,7 +45,7 @@ module Apivore
           if [current_service] == definition_fields['x-services']
             nil
           else
-            # 'x-services' is added the aggregated swagger doc provided by api.westfield.io
+            # 'x-services' is added by api.westfield.io when aggregating swagger docs
             # Individual services will not have a 'x-services' property so we need to remove it to allow the comparison to pass
             definition_fields.except 'x-services'
           end

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -42,8 +42,8 @@ module Apivore
       match do |body|
         our_swagger = JSON.parse(body)
         master_definitions = master_swagger["definitions"].transform_values do |definition|
-          # 'x-source' is added by api.westfield.io - services shouldn't need to define it
-          definition.tap{|d|d.delete 'x-source'}
+          # 'x-services' is added by api.westfield.io - services shouldn't need to define it
+          definition.tap{|d|d.delete 'x-services'}
         end
         our_definitions = our_swagger["definitions"]
         @actual = our_definitions.slice(*master_definitions.keys)


### PR DESCRIPTION
Usage:

```
apivore_check_consistency_with_swagger_at "api.westfield.io", "search"
```

If the only conflicts are in definitions that come from search service (in this case), then the tests will pass. If the conflicts involve more than one service, or a service that isn't "search", then the tests will fail, as they should.
 
This should be both forward and backward compatible with x-services in swagger.json, and the previous usage, ```apivore_check_consistency_with_swagger_at "api.westfield.io"```.