### PR TITLE
FEATURE [RTLR-194] make error messages clearer

### DIFF
--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -72,7 +72,7 @@ module Apivore
       end
 
       failure_message do |body|
-        @errors.map { |e| e.gsub(/^The property|in schema.*$/,'') }.join("\n")
+        @errors.map { |e| e.sub("'#", "'#{path}#").gsub(/^The property|in schema.*$/,'') }.join("\n")
       end
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -19,7 +19,7 @@ context "Apivore tests running against a mock API" do
     it 'should show which path and field has the problem for both index and view' do
       stdout = `rspec spec/data/example_specs.rb --example 'mismatched property type'`
       expect(stdout).to match(/2 failures/)
-      expect(stdout).to match("'#/name' of type String did not match one or more of the following types: integer, null")
+      expect(stdout).to match("'/api/services/1.json#/name' of type String did not match one or more of the following types: integer, null")
     end
   end
 
@@ -46,8 +46,8 @@ context "Apivore tests running against a mock API" do
       # This swagger doc does not document one of the properties returned by the mock API
       stdout = `rspec spec/data/example_specs.rb --example 'extra properties'`
       expect(stdout).to match(/2 failures/)
-      expect(stdout).to match("'#/0' contained undefined properties: 'name'") # Index
-      expect(stdout).to match("'#/' contained undefined properties: 'name'")  # View
+      expect(stdout).to match("'/api/services.json#/0' contained undefined properties: 'name'") # Index
+      expect(stdout).to match("'/api/services/1.json#/' contained undefined properties: 'name'")  # View
     end
   end
 
@@ -55,8 +55,8 @@ context "Apivore tests running against a mock API" do
     it 'should fail on the missing property for both index and view' do
       stdout = `rspec spec/data/example_specs.rb --example 'missing required'`
       expect(stdout).to match(/2 failures/)
-      expect(stdout).to match("'#/0' did not contain a required property of 'test_required'") # Index
-      expect(stdout).to match("'#/' did not contain a required property of 'test_required'")  # View
+      expect(stdout).to match("'/api/services.json#/0' did not contain a required property of 'test_required'") # Index
+      expect(stdout).to match("'/api/services/1.json#/' did not contain a required property of 'test_required'")  # View
     end
   end
 


### PR DESCRIPTION
https://jira.westfieldlabs.com/browse/RTLR-194

Changing error output from:
```
Failure/Error: expect(response.body).to conform_to_the_documented_model_for(swagger, fragment)
        '#/0' contained undefined properties: 'name'
```
to
```
    Failure/Error: expect(response.body).to conform_to_the_documented_model_for(swagger, fragment)
        '/api/services.json#/0' contained undefined properties: 'name'
```
to make it clearer that it is a json ref path in a particular response, because the '#/' doesn't seem very meaningful by itself. Is this an improvement on the above?