### PR TITLE
Permit setup and substitution params on any combination of path, method, and response

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ describe "the API" do
   validate("api/swagger.json")
 end
 ```
+
+`apivore_setup` blocks can be specified against a combination of path, method, and response, or left blank for base setup code to be called before all tests. For each test against a swagger path expected response, all matching code blocks are executed, and substitution parameters are merged in order of specificity. Have a look at the [spec tests](spec/rspec_builder_spec.rb) for more examples and expected outcomes.
+
+**Examples**
+```ruby
+apivore_setup do
+  # Put general test stub code here which will be executed before all path tests
+  { 'id' => 1, 'name' => 'michel' }
+end
+
+apivore_setup "get", "200" do
+  # This block only applies to GET path tests where the expected result is a 200 response code
+  { 'id' => 2, 'name' => 'dora' }
+end
+```
+
 A query string can be specified with the `_query_string` key as follows:
 
 ```ruby

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -14,16 +14,31 @@ module Apivore
 
     @@master_swagger_uri = nil
 
-    def apivore_setup(path, method, response, &block)
+    def apivore_setup(path = '', method = '', response = '', &block)
       @@setups[path + method + response] = block
     end
 
     def get_apivore_setup(path, method, response)
-      setup = @@setups[path + method + response]
-      if setup
-        result = instance_eval &setup
+      keys_to_search = [
+        '', # base setup key
+        response,
+        method,
+        path,
+        method + response,
+        # Is there a use-case for the following two? Added for completeness
+        # path + response,
+        # path + method,
+        path + method + response
+      ]
+      final_result = {}
+      keys_to_search.each do |k|
+        setup = @@setups[k]
+        if setup
+          result = instance_eval &setup
+          final_result.merge!(result) if result.is_a?(Hash)
+        end
       end
-      (result && result.is_a?(Hash)) ? result : {}
+      final_result
     end
 
     def apivore_build_path(path, data)

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -29,7 +29,6 @@ module Apivore
         method,
         path,
         method + response,
-        # Is there a use-case for the following two? Added for completeness
         path + response,
         path + method,
         path + method + response

--- a/lib/apivore/rspec_builder.rb
+++ b/lib/apivore/rspec_builder.rb
@@ -14,8 +14,12 @@ module Apivore
 
     @@master_swagger_uri = nil
 
-    def apivore_setup(path = '', method = '', response = '', &block)
-      @@setups[path + method + response] = block
+    # Setup tests against a combination of path, method, and response.
+    # - *keys -> A combination of path, method, and/or response. Blank '' for base setup.
+    # - &block -> Code block to execute to setup the test. A hash of path subsitution parameters can be returned if required.
+    # All matching code blocks are executed, and substitution parameters are merged in order of specificity.
+    def apivore_setup(*keys, &block)
+      @@setups[keys.join] = block
     end
 
     def get_apivore_setup(path, method, response)
@@ -26,8 +30,8 @@ module Apivore
         path,
         method + response,
         # Is there a use-case for the following two? Added for completeness
-        # path + response,
-        # path + method,
+        path + response,
+        path + method,
         path + method + response
       ]
       final_result = {}

--- a/spec/rspec_builder_spec.rb
+++ b/spec/rspec_builder_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+include Apivore::RspecBuilder
+
+describe 'Apivore::RspecBuilder' do
+  let(:dummy_class) { Class.new { include RspecBuilder } }
+  subject { :dummy_class }
+
+  it { should respond_to(:apivore_setup) } 
+  it { should respond_to(:get_apivore_setup) }
+
+  it "should merge relevant setup blocks in order of least to most specific" do
+    apivore_setup do
+      { 'id' => 1, 'name' => 'michel' }
+    end
+
+    apivore_setup "/thing", "get", "200" do
+      { 'content' => 'test', 'name' => 'francois' }
+    end
+
+    apivore_setup "get", "200" do
+      { 'id' => 2, 'name' => 'dora' }
+    end
+
+    apivore_setup "500" do
+      { 'id' => 5 }
+    end
+
+    expect(get_apivore_setup("/thing", "get", "200")).to eq({'id' => 2, 'name' => 'francois', 'content' => 'test'})
+    expect(get_apivore_setup("/thing", "get", "500")).to eq({'id' => 5, 'name' => 'michel'})
+  end
+end


### PR DESCRIPTION
I think this covers the basic requirements of PEEPS-440 and PEEPS-441:
*Permit setup only on response codes*
*Permit base request arguments to be defined for all documented routes*

@jgalilee, could you please review and check that this satisfies the requirements you suggested? The implementation is a bit different, and allows for other combinations, but I think it gives the flexibility you were after.

Hopefully the test makes it clear how the setups work now.

If it looks good, I'll need to modify the readme for the expanded usage.