### PR TITLE
[Feature, CNTR-358] Work out how to properly represent optional properties in Swagger

### DIFF
--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -2,14 +2,14 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'apivore'
-  s.version     = '0.0.1'
+  s.version     = '0.0.2'
   s.date        = '2014-11-16'
   s.summary     = "Automatically tests your API using its Swagger description of end-points, models, and query parameters."
   s.description = "Automatically tests your API using its Swagger description of end-points, models, and query parameters."
   s.authors     = ["Charles Horn"]
   s.email       = 'charles.horn@gmail.com'
   s.files       = ['lib/apivore.rb', 'lib/apivore/rspec_matchers.rb', 'lib/apivore/rspec_builder.rb', 'data/swagger_2.0_schema.json']
-  s.homepage    = 'http://github.com/hornc/apivore'
+  s.homepage    = 'http://github.com/westfieldlabs/apivore'
   s.add_runtime_dependency 'json-schema', '~> 2.5.1'
   s.add_runtime_dependency 'rspec-expectations', '~> 3.1'
   s.add_runtime_dependency 'rspec-mocks', '~> 3.1'

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -67,7 +67,7 @@ module Apivore
     matcher :conform_to_the_documented_model_for do |swagger, fragment|
       match do |body|
         body = JSON.parse(body)
-        @errors = JSON::Validator.fully_validate(swagger, body, fragment: fragment, strict: true)
+        @errors = JSON::Validator.fully_validate(swagger, body, fragment: fragment)
         @errors.empty?
       end
 

--- a/spec/data/05_extra_properties.json
+++ b/spec/data/05_extra_properties.json
@@ -58,7 +58,8 @@
           "description": "Service id",
           "extra_swagger_property": "true"
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/spec/data/07_missing_non-required_property.json
+++ b/spec/data/07_missing_non-required_property.json
@@ -60,9 +60,7 @@
         "name": {
           "type": ["string", "null"],
           "description": "Service name"
-        }
-      },
-      "additionalProperties": {
+        },
         "test_non-required": {
           "type": ["string"],
           "description": "Test property to see how apivore behaves when this field is not present in a response"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -31,23 +31,14 @@ context "Apivore tests running against a mock API" do
     end
   end
 
-  describe "a response containing extra (undocumented) properties (configured with non-strict validation)" do
-    it 'should pass validation' do
-      pending "needs configurable option to allow :strict => false validation"
-      # TODO: set configuration to validate :strict => true so the strictness behaviour is configurable
-      # This swagger doc does not document one of the properties returned by the mock API
-      stdout = `rspec spec/data/example_specs.rb --example 'extra properties'`
-      expect(stdout).to match(/0 failures/)
-    end
-  end
-
-  describe "a response containing extra (undocumented) properties (default strict validation)" do
+  describe "a response containing extra (undocumented) properties where additionalProperties: false " do
     it 'should fail on undocumented properties for both index and view' do
       # This swagger doc does not document one of the properties returned by the mock API
       stdout = `rspec spec/data/example_specs.rb --example 'extra properties'`
       expect(stdout).to match(/2 failures/)
-      expect(stdout).to match("'/api/services.json#/0' contained undefined properties: 'name'") # Index
-      expect(stdout).to match("'/api/services/1.json#/' contained undefined properties: 'name'")  # View
+      msg = 'contains additional properties \["name"\] outside of the schema when none are allowed'
+      expect(stdout).to match("'/api/services.json#/0' #{msg}") # Index
+      expect(stdout).to match("'/api/services/1.json#/' #{msg}") # View
     end
   end
 


### PR DESCRIPTION
Optional properties should be represented in Swagger by specifying all properties under `properties`, and listing the required ones in `required`.

The previous usage of `additionalProperties` happened to work here, but was not picked up by swagger-codegen. Using `required` is the correct method.

The original misunderstanding in Apivore stemmed from the desire to catch undocumented properties in json data. It turns out that, by default, undocumented properties are accepted as valid in json-schema, and therefore by extension in Swagger 2.0.

To cause undocumented properties in an api response to trigger a validation failure `additionalProperties` must be explicitly set to `false` in the Swagger document, as in [this test example] (spec/data/05_extra_properties.json))

The result of the investigation showed that the json-schema's 'strict' mode isn't very well defined or helpful, and unnecessary for what we are trying to do here. We want 'proper' json validation, and that's what the default mode gives us.

The result of this change is that now the onus is on the author of the swagger doc to disallow undocumented properties in their API description by setting `"additionalProperties": false`