### PR TITLE
require rspec so RSpec.configure won't fail

### DIFF
--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.files       = ['lib/apivore.rb', 'lib/apivore/*', 'data/swagger_2.0_schema.json']
   s.homepage    = 'http://github.com/westfieldlabs/apivore'
   s.add_runtime_dependency 'json-schema', '~> 2.5.1'
+  s.add_runtime_dependency 'rspec', '~> 3'
   s.add_runtime_dependency 'rspec-expectations', '~> 3.1'
   s.add_runtime_dependency 'rspec-mocks', '~> 3.1'
   s.add_runtime_dependency 'actionpack', '~> 4'

--- a/lib/apivore.rb
+++ b/lib/apivore.rb
@@ -2,6 +2,7 @@ require 'apivore/rspec_matchers'
 require 'apivore/rspec_helpers'
 require 'apivore/swagger_checker'
 require 'apivore/swagger'
+require 'rspec/rails'
 
 RSpec.configure do |config|
   config.include Apivore::RspecMatchers, type: :apivore

--- a/lib/apivore.rb
+++ b/lib/apivore.rb
@@ -2,7 +2,7 @@ require 'apivore/rspec_matchers'
 require 'apivore/rspec_helpers'
 require 'apivore/swagger_checker'
 require 'apivore/swagger'
-require 'rspec/rails'
+require 'rspec'
 
 RSpec.configure do |config|
   config.include Apivore::RspecMatchers, type: :apivore


### PR DESCRIPTION
I've come across the following error in two applications when I tried to move them over the the new version:

```
NoMethodError: undefined method `configure' for RSpec:Module
/Users/charles/westfield/apivore/lib/apivore.rb:6:in `<top (required)>'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:76:in `require'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:72:in `each'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:72:in `block in require'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:61:in `each'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler/runtime.rb:61:in `require'
/Users/charles/.rvm/gems/ruby-2.2.0@global/gems/bundler-1.7.12/lib/bundler.rb:134:in `require'
/Users/charles/westfield/app_service/config/application.rb:14:in `<top (required)>'
/Users/charles/westfield/app_service/Rakefile:4:in `require'
/Users/charles/westfield/app_service/Rakefile:4:in `<top (required)>'
/Users/charles/.rvm/gems/ruby-2.2.0/bin/ruby_executable_hooks:15:in `eval'
/Users/charles/.rvm/gems/ruby-2.2.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

It does not error when running deal_service tests, but I think that has rspec/rails included from elsewhere.

Is this the best place to require this here?