### PR TITLE
Update Swagger 2.0 schema and include local draft04 to prevent network calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apivore (1.0.0)
+    apivore (1.1.0)
       actionpack (~> 4)
       hashie (~> 3.3)
       json-schema (~> 2.5)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ limitations under the License.
 
 This project includes and makes use of the [Swagger 2.0 schema json](http://swagger.io/v2/schema.json) (Copyright 2014 Reverb Technologies, Inc. Released under the [MIT license](http://opensource.org/licenses/MIT)) included here as `data/swagger_2.0_schema.json`
 
-It also includes a copy of http://json-schema.org/draft-04/schema, included as `data/draft04_schema.json`. These schemas are included to prevent network resource fetching and speed up validation times considerably.
+It also includes a copy of http://json-schema.org/draft-04/schema, included as `data/draft04_schema.json`. These schemata are included to prevent network resource fetching and speed up validation times considerably.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Run the tests as part of your normal rspec test suite, e.g., `rake spec:requests
 
 * http://json-schema.org/
 * https://github.com/swagger-api/swagger-spec
-* https://github.com/hoxworth/json-schema
+* https://github.com/ruby-json-schema/json-schema
 
 ## License
 
@@ -100,9 +100,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-This project includes and makes use of a modified version of the [Swagger 2.0 schema json](https://github.com/swagger-api/swagger-spec/blob/master/schemas/v2.0/schema.json) (Copyright 2014 Reverb Technologies, Inc. Released under the [MIT license](http://opensource.org/licenses/MIT)) included here as `data/swagger_2.0_schema.json`
+This project includes and makes use of the [Swagger 2.0 schema json](http://swagger.io/v2/schema.json) (Copyright 2014 Reverb Technologies, Inc. Released under the [MIT license](http://opensource.org/licenses/MIT)) included here as `data/swagger_2.0_schema.json`
 
-The modifications involve explicitly including in the previously external references to http://json-schema.org/draft-04/schema to prevent network resource fetching and speed up validation times considerably.
+It also includes a copy of http://json-schema.org/draft-04/schema, included as `data/draft04_schema.json`. These schemas are included to prevent network resource fetching and speed up validation times considerably.
 
 ## Contributors
 

--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -2,13 +2,13 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'apivore'
-  s.version     = '1.0.0'
-  s.date        = '2014-11-16'
+  s.version     = '1.1.0'
+  s.date        = '2015-05-11'
   s.summary     = "Tests your API against its Swagger 2.0 spec"
   s.description = "Tests your rails API using its Swagger description of end-points, models, and query parameters."
   s.authors     = ["Charles Horn"]
   s.email       = 'charles.horn@gmail.com'
-  s.files       = ['lib/apivore.rb', 'data/swagger_2.0_schema.json']
+  s.files       = ['lib/apivore.rb', 'data/swagger_2.0_schema.json', 'data/draft04_schema.json]
   s.files      += Dir['lib/apivore/*.rb']
   s.homepage    = 'http://github.com/westfieldlabs/apivore'
   s.licenses    = ['Apache 2.0', 'MIT']

--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = "Tests your rails API using its Swagger description of end-points, models, and query parameters."
   s.authors     = ["Charles Horn"]
   s.email       = 'charles.horn@gmail.com'
-  s.files       = ['lib/apivore.rb', 'data/swagger_2.0_schema.json', 'data/draft04_schema.json]
+  s.files       = ['lib/apivore.rb', 'data/swagger_2.0_schema.json', 'data/draft04_schema.json']
   s.files      += Dir['lib/apivore/*.rb']
   s.homepage    = 'http://github.com/westfieldlabs/apivore'
   s.licenses    = ['Apache 2.0', 'MIT']

--- a/data/draft04_schema.json
+++ b/data/draft04_schema.json
@@ -1,0 +1,150 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/data/swagger_2.0_schema.json
+++ b/data/swagger_2.0_schema.json
@@ -214,7 +214,6 @@
     },
     "mimeType": {
       "type": "string",
-      "pattern": "^[\\sa-z0-9\\-+;\\.=\\/]+$",
       "description": "The MIME type of the HTTP message."
     },
     "operation": {
@@ -605,6 +604,11 @@
           "type": "string",
           "description": "The name of the parameter."
         },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
+        },
         "type": {
           "type": "string",
           "enum": [
@@ -692,6 +696,11 @@
         "name": {
           "type": "string",
           "description": "The name of the parameter."
+        },
+        "allowEmptyValue": {
+          "type": "boolean",
+          "default": false,
+          "description": "allows sending a parameter by name only or with an empty value."
         },
         "type": {
           "type": "string",
@@ -892,69 +901,64 @@
           "type": "string"
         },
         "title": {
-          "$ref": "#/definitions/title"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
         },
         "description": {
-          "$ref": "#/definitions/description"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
         },
         "default": {
-          "$ref": "#/definitions/default"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
         },
         "multipleOf": {
-          "$ref": "#/definitions/multipleOf"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
         },
         "maximum": {
-          "$ref": "#/definitions/maximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
         },
         "exclusiveMaximum": {
-          "$ref": "#/definitions/exclusiveMaximum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
         },
         "minimum": {
-          "$ref": "#/definitions/minimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
         },
         "exclusiveMinimum": {
-          "$ref": "#/definitions/exclusiveMinimum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
         },
         "maxLength": {
-          "$ref": "#/definitions/maxLength"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minLength": {
-          "$ref": "#/definitions/minLength"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "pattern": {
-          "$ref": "#/definitions/pattern"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
         },
         "maxItems": {
-          "$ref": "#/definitions/maxItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minItems": {
-          "$ref": "#/definitions/minItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "uniqueItems": {
-          "$ref": "#/definitions/uniqueItems"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
         },
         "maxProperties": {
-          "$ref": "#/definitions/positiveInteger"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
         },
         "minProperties": {
-          "$ref": "#/definitions/positiveIntegerDefault0"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
         },
         "required": {
-          "$ref": "#/definitions/stringArray"
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
         },
         "enum": {
-          "$ref": "#/definitions/enum"
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
+        },
+        "additionalProperties": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/additionalProperties"
         },
         "type": {
-          "anyOf": [
-                { "$ref": "#/definitions/simpleTypes" },
-                {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/simpleTypes" },
-                    "minItems": 1,
-                    "uniqueItems": true
-                }
-            ]
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
         },
         "items": {
           "anyOf": [
@@ -999,7 +1003,8 @@
           "$ref": "#/definitions/externalDocs"
         },
         "example": {}
-      }
+      },
+      "additionalProperties": false
     },
     "primitivesItems": {
       "type": "object",
@@ -1384,7 +1389,6 @@
     "parametersList": {
       "type": "array",
       "description": "The parameters needed to send a valid API call.",
-      "minItems": 1,
       "additionalItems": false,
       "items": {
         "oneOf": [
@@ -1434,55 +1438,49 @@
       "default": "csv"
     },
     "title": {
-      "type": "string"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
     },
     "description": {
-      "type": "string"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
     },
-    "default": { },
+    "default": {
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+    },
     "multipleOf": {
-        "type": "number",
-        "minimum": 0,
-        "exclusiveMinimum": true
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/multipleOf"
     },
     "maximum": {
-      "type": "number"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/maximum"
     },
     "exclusiveMaximum": {
-      "type": "boolean",
-      "default": false
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum"
     },
     "minimum": {
-      "type": "number"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/minimum"
     },
     "exclusiveMinimum": {
-      "type": "boolean",
-      "default": false
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum"
     },
     "maxLength": {
-      "$ref": "#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minLength": {
-      "$ref": "#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "pattern": {
-      "type": "string",
-      "format": "regex"
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/pattern"
     },
     "maxItems": {
-      "$ref": "#/definitions/positiveInteger"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveInteger"
     },
     "minItems": {
-      "$ref": "#/definitions/positiveIntegerDefault0"
+      "$ref": "http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0"
     },
     "uniqueItems": {
-      "type": "boolean",
-      "default": false
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/uniqueItems"
     },
     "enum": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true
+      "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
     },
     "jsonReference": {
       "type": "object",
@@ -1492,22 +1490,6 @@
           "type": "string"
         }
       }
-    },
-    "simpleTypes": {
-      "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
-    },
-    "stringArray": {
-      "type": "array",
-      "items": { "type": "string" },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "positiveInteger": {
-      "type": "integer"
-    },
-    "positiveIntegerDefault0": {
-      "type": "integer",
-      "default": 0
     }
   }
 }

--- a/lib/apivore.rb
+++ b/lib/apivore.rb
@@ -1,10 +1,16 @@
+require 'json-schema'
+require 'rspec'
 require 'apivore/rspec_matchers'
 require 'apivore/rspec_helpers'
 require 'apivore/swagger_checker'
 require 'apivore/swagger'
-require 'rspec'
 
 RSpec.configure do |config|
   config.include Apivore::RspecMatchers, type: :apivore
   config.include Apivore::RspecHelpers, type: :apivore
 end
+
+# Load and register a local copy of the draft04 JSON schema to prevent network calls when resolving $refs from the swagger 2.0 schema
+draft04 = JSON.parse(File.read(File.expand_path("../../data/draft04_schema.json", __FILE__)))
+draft04_schema = JSON::Schema.new(draft04, Addressable::URI.parse('http://json-schema.org/draft-04/schema#'))
+JSON::Validator.add_schema(draft04_schema)

--- a/lib/apivore/rspec_matchers.rb
+++ b/lib/apivore/rspec_matchers.rb
@@ -1,4 +1,3 @@
-require 'json-schema'
 require 'rspec/expectations'
 require 'net/http'
 

--- a/spec/data/05_extra_properties.json
+++ b/spec/data/05_extra_properties.json
@@ -55,8 +55,7 @@
       "properties": {
         "id": {
           "type": "integer",
-          "description": "Service id",
-          "extra_swagger_property": "true"
+          "description": "Service id"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Previously Apivore used a modified version of the Swagger 2.0 spec that manually included the contents of the $refs to the draft04 schema. Forming this was a manual process. 

This PR uses the latest unmodified Swagger 2.0 spec and draft04 and takes advantage of a feature of `json-schema` that lets us register an external resource locally. This makes getting the latest version of either easier to update and include.
