### PR TITLE
Tidy Custom Schema validation usage, and use latest swagger 2.0 spec

### DIFF
--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 Gem::Specification.new do |s|
   s.name        = 'apivore'
   s.version     = '1.3.0'
-  s.date        = '2015-06-11'
+  s.date        = '2015-07-31'
   s.summary     = "Tests your API against its Swagger 2.0 spec"
   s.description = "Tests your rails API using its Swagger description of end-points, models, and query parameters."
   s.authors     = ["Charles Horn"]

--- a/data/swagger_2.0_schema.json
+++ b/data/swagger_2.0_schema.json
@@ -27,9 +27,8 @@
     },
     "host": {
       "type": "string",
-      "format": "uri",
       "pattern": "^[^{}/ :\\\\]+(?::\\d+)?$",
-      "description": "The fully qualified URI to the host of the API."
+      "description": "The host (name or ip) of the API. Example: 'swagger.io'"
     },
     "basePath": {
       "type": "string",
@@ -101,7 +100,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A longer description of the API. Should be different from the title.  Github-flavored markdown is allowed."
+          "description": "A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed."
         },
         "termsOfService": {
           "type": "string",
@@ -134,6 +133,11 @@
           "description": "The email address of the contact person/organization.",
           "format": "email"
         }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
       }
     },
     "license": {
@@ -151,6 +155,11 @@
           "type": "string",
           "description": "The URL pointing to the license.",
           "format": "uri"
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
         }
       }
     },
@@ -203,14 +212,16 @@
           "type": "string",
           "format": "uri"
         }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
       }
     },
     "examples": {
       "type": "object",
-      "patternProperties": {
-        "^[a-z0-9-]+/[a-z0-9\\-+]+$": {}
-      },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "mimeType": {
       "type": "string",
@@ -241,14 +252,14 @@
         },
         "description": {
           "type": "string",
-          "description": "A longer description of the operation, github-flavored markdown is allowed."
+          "description": "A longer description of the operation, GitHub Flavored Markdown is allowed."
         },
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
         },
         "operationId": {
           "type": "string",
-          "description": "A friendly name of the operation"
+          "description": "A unique identifier of the operation."
         },
         "produces": {
           "description": "A list of MIME types the API can produce.",
@@ -357,7 +368,14 @@
           "type": "string"
         },
         "schema": {
-          "$ref": "#/definitions/schema"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "$ref": "#/definitions/fileSchema"
+            }
+          ]
         },
         "headers": {
           "$ref": "#/definitions/headers"
@@ -366,7 +384,12 @@
           "$ref": "#/definitions/examples"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      }
     },
     "headers": {
       "type": "object",
@@ -442,6 +465,11 @@
         "description": {
           "type": "string"
         }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
       }
     },
     "vendorExtension": {
@@ -464,7 +492,7 @@
       "properties": {
         "description": {
           "type": "string",
-          "description": "A brief description of the parameter. This could contain examples of use.  Github-flavored markdown is allowed."
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
         },
         "name": {
           "type": "string",
@@ -510,7 +538,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A brief description of the parameter. This could contain examples of use.  Github-flavored markdown is allowed."
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
         },
         "name": {
           "type": "string",
@@ -598,7 +626,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A brief description of the parameter. This could contain examples of use.  Github-flavored markdown is allowed."
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
         },
         "name": {
           "type": "string",
@@ -691,7 +719,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A brief description of the parameter. This could contain examples of use.  Github-flavored markdown is allowed."
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
         },
         "name": {
           "type": "string",
@@ -770,6 +798,9 @@
           "$ref": "#/definitions/vendorExtension"
         }
       },
+      "required": [
+        "required"
+      ],
       "properties": {
         "required": {
           "type": "boolean",
@@ -787,7 +818,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A brief description of the parameter. This could contain examples of use.  Github-flavored markdown is allowed."
+          "description": "A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed."
         },
         "name": {
           "type": "string",
@@ -955,7 +986,15 @@
           "$ref": "http://json-schema.org/draft-04/schema#/properties/enum"
         },
         "additionalProperties": {
-          "$ref": "http://json-schema.org/draft-04/schema#/properties/additionalProperties"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/schema"
+            },
+            {
+              "type": "boolean"
+            }
+          ],
+          "default": {}
         },
         "type": {
           "$ref": "http://json-schema.org/draft-04/schema#/properties/type"
@@ -998,6 +1037,47 @@
         },
         "xml": {
           "$ref": "#/definitions/xml"
+        },
+        "externalDocs": {
+          "$ref": "#/definitions/externalDocs"
+        },
+        "example": {}
+      },
+      "additionalProperties": false
+    },
+    "fileSchema": {
+      "type": "object",
+      "description": "A deterministic version of a JSON Schema object.",
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "title": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/title"
+        },
+        "description": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/description"
+        },
+        "default": {
+          "$ref": "http://json-schema.org/draft-04/schema#/properties/default"
+        },
+        "required": {
+          "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "file"
+          ]
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false
         },
         "externalDocs": {
           "$ref": "#/definitions/externalDocs"
@@ -1068,6 +1148,11 @@
         "multipleOf": {
           "$ref": "#/definitions/multipleOf"
         }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
+        }
       }
     },
     "security": {
@@ -1107,6 +1192,11 @@
         "wrapped": {
           "type": "boolean",
           "default": false
+        }
+      },
+      "patternProperties": {
+        "^x-": {
+          "$ref": "#/definitions/vendorExtension"
         }
       }
     },
@@ -1484,6 +1574,9 @@
     },
     "jsonReference": {
       "type": "object",
+      "required": [
+        "$ref"
+      ],
       "additionalProperties": false,
       "properties": {
         "$ref": {

--- a/lib/apivore/custom_schema_validator.rb
+++ b/lib/apivore/custom_schema_validator.rb
@@ -1,7 +1,10 @@
 module Apivore
   class CustomSchemaValidator
+    # This constant is an example custom schema included with the gem
+    WF_SCHEMA = File.expand_path("../../data/custom_schemata/westfield_api_standards.json", File.dirname(__FILE__))
+
     def initialize(custom_schema)
-      @schema = File.expand_path("../../data/custom_schemata/#{custom_schema}", File.dirname(__FILE__))
+      @schema = custom_schema
     end
 
     def matches?(swagger_checker)

--- a/spec/data/example_specs.rb
+++ b/spec/data/example_specs.rb
@@ -69,7 +69,7 @@ context "API testing scenarios" do
     end
 
     it "fails" do
-      expect(subject).to conform_to("westfield_api_standards.json")
+      expect(subject).to conform_to(Apivore::CustomSchemaValidator::WF_SCHEMA)
     end
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -46,7 +46,7 @@ describe "Example API", type: :apivore, order: :defined do
     end
 
     it 'additionally conforms to a custom schema' do
-      expect(subject).to conform_to("westfield_api_standards.json")
+      expect(subject).to conform_to(Apivore::CustomSchemaValidator::WF_SCHEMA)
     end
     # it 'has definitions consistent with the master docs' do
     #   expect(subject).to be_consistent_with_swagger_definitions(


### PR DESCRIPTION
This includes the updated swagger 2.0 spec, but also a revision on how the example custom schema validation should be used. It uses a constant to point to the Westfield custom schema which is included in the gem as an 'example'.