### PR TITLE
Skip path items that are not HTTP verbs

### DIFF
--- a/lib/apivore/swagger.rb
+++ b/lib/apivore/swagger.rb
@@ -4,6 +4,7 @@ require 'apivore/fragment'
 
 module Apivore
   class Swagger < Hashie::Mash
+    NONVERB_PATH_ITEMS = %q(parameters)
 
     def validate
       case version
@@ -26,6 +27,7 @@ module Apivore
     def each_response(&block)
       paths.each do |path, path_data|
         path_data.each do |verb, method_data|
+          next if NONVERB_PATH_ITEMS.include?(verb)
           raise "No responses found in swagger for path '#{path}', method #{verb}: #{method_data.inspect}" if method_data.responses.nil?
           method_data.responses.each do |response_code, response_data|
             schema_location = nil


### PR DESCRIPTION
As they don't correspond to resource routes, currently this just
includes `parameters`.

See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#path-item-object

Addresses #59 