### PR TITLE
Update test/example swagger to include path parameters

### DIFF
--- a/spec/data/sample2.0.json
+++ b/spec/data/sample2.0.json
@@ -49,7 +49,7 @@
             "in": "path",
             "description": "Service identifier.",
             "required": true,
-            "type": "string"
+            "type": "integer"
           }
         ],
         "get": {

--- a/spec/data/sample2.0.json
+++ b/spec/data/sample2.0.json
@@ -46,8 +46,9 @@
         "parameters": [
           {
             "name": "id",
-            "in": "query",
+            "in": "path",
             "description": "Service identifier.",
+            "required": true,
             "type": "string"
           }
         ],

--- a/spec/data/sample2.0.json
+++ b/spec/data/sample2.0.json
@@ -43,6 +43,14 @@
         }
       },
       "/services/{id}.json": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "description": "Service identifier.",
+            "type": "string"
+          }
+        ],
         "get": {
           "description": "Returns a service.",
           "operationId": "Services#show",


### PR DESCRIPTION
This adds an example of the feature provided by https://github.com/westfieldlabs/apivore/pull/60 to the example swagger used in the tests.
