### PR TITLE
Better debugging and response access

### DIFF
--- a/lib/apivore/swagger_checker.rb
+++ b/lib/apivore/swagger_checker.rb
@@ -45,7 +45,11 @@ module Apivore
       @swagger.base_path
     end
 
-    attr_reader :swagger_path, :untested_mappings, :swagger
+    def response=(response)
+      @response = response
+    end
+
+    attr_reader :response, :swagger, :swagger_path, :untested_mappings
 
     private
 

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -81,7 +81,8 @@ module Apivore
     def check_status_code
       if response.status != expected_response_code
         errors << "Path #{path} did not respond with expected status code."\
-          " Expected #{expected_response_code} got #{response.status}"
+          " Expected #{expected_response_code} got #{response.status}"\
+          "\nResponse body: #{response.body}"
       end
     end
 

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -24,6 +24,7 @@ module Apivore
           params['_data'] || {},
           params['_headers'] || {}
         )
+        swagger_checker.response = response
         post_checks(swagger_checker)
         swagger_checker.remove_tested_end_point_response(
           path, method, expected_response_code


### PR DESCRIPTION
This makes the last response available on the SwaggerChecker, the `subject` of the tests.

This will help with debugging, and enable
`expect(subject.response).to <something>` additional verifications, perhaps to ensure a response is not empty and trivially passing the json schema validations.