### PR TITLE
Print response body when test fails (v2)

### DIFF
--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -2,8 +2,8 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'apivore'
-  s.version     = '1.4.3'
-  s.date        = '2015-12-08'
+  s.version     = '1.4.5'
+  s.date        = '2016-01-14'
   s.summary     = "Tests your API against its Swagger 2.0 spec"
   s.description = "Tests your rails API using its Swagger description of end-points, models, and query parameters."
   s.authors     = ["Charles Horn"]

--- a/lib/apivore/swagger_checker.rb
+++ b/lib/apivore/swagger_checker.rb
@@ -18,6 +18,10 @@ module Apivore
       mappings[path][method].has_key?(code.to_s)
     end
 
+    def response_codes_for_path(path, method)
+      mappings[path][method].keys.join(", ")
+    end
+
     def has_matching_document_for(path, method, code, body)
       JSON::Validator.fully_validate(
         swagger, body, fragment: fragment(path, method, code)

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -28,10 +28,7 @@ module Apivore
         post_checks(swagger_checker)
 
         if has_errors? && response.body.length > 0
-          puts "XXXXXXXXXXXXXXXX"
-          puts "Response body for '#{method} #{full_path(swagger_checker)}'\n"
-          puts JSON.pretty_generate(JSON.parse(response.body))
-          puts "XXXXXXXXXXXXXXXX"
+          errors << "\nResponse body:\n #{JSON.pretty_generate(JSON.parse(response.body))}"
         end
 
         swagger_checker.remove_tested_end_point_response(
@@ -58,7 +55,6 @@ module Apivore
       end
       path + (data['_query_string'] ? "?#{data['_query_string']}" : '')
     end
-
 
     def pre_checks(swagger_checker)
       check_request_path(swagger_checker)
@@ -92,7 +88,6 @@ module Apivore
       if response.status != expected_response_code
         errors << "Path #{path} did not respond with expected status code."\
           " Expected #{expected_response_code} got #{response.status}"\
-          "\nResponse body: #{response.body}"
       end
     end
 

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -27,7 +27,7 @@ module Apivore
         swagger_checker.response = response
         post_checks(swagger_checker)
 
-        if has_errors?
+        if has_errors? && response.body.length > 0
           puts "XXXXXXXXXXXXXXXX"
           puts "Response body for '#{method} #{full_path(swagger_checker)}'\n"
           puts JSON.pretty_generate(JSON.parse(response.body))

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -17,7 +17,12 @@ module Apivore
     def matches?(swagger_checker)
       pre_checks(swagger_checker)
 
-      unless has_errors?
+      if has_errors?
+        puts "XXXXXXXXXXXXXXXX"
+        puts "Response body for '#{method} #{full_path(swagger_checker)}'\n"
+        puts JSON.pretty_generate(JSON.parse(response.body))
+        puts "XXXXXXXXXXXXXXXX"
+      else
         send(
           method,
           full_path(swagger_checker),

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -17,12 +17,7 @@ module Apivore
     def matches?(swagger_checker)
       pre_checks(swagger_checker)
 
-      if has_errors?
-        puts "XXXXXXXXXXXXXXXX"
-        puts "Response body for '#{method} #{full_path(swagger_checker)}'\n"
-        puts JSON.pretty_generate(JSON.parse(response.body))
-        puts "XXXXXXXXXXXXXXXX"
-      else
+      unless has_errors?
         send(
           method,
           full_path(swagger_checker),
@@ -31,6 +26,14 @@ module Apivore
         )
         swagger_checker.response = response
         post_checks(swagger_checker)
+
+        if has_errors?
+          puts "XXXXXXXXXXXXXXXX"
+          puts "Response body for '#{method} #{full_path(swagger_checker)}'\n"
+          puts JSON.pretty_generate(JSON.parse(response.body))
+          puts "XXXXXXXXXXXXXXXX"
+        end
+
         swagger_checker.remove_tested_end_point_response(
           path, method, expected_response_code
         )
@@ -76,7 +79,8 @@ module Apivore
       elsif !swagger_checker.has_response_code_for_path?(path, method, expected_response_code)
         errors << "Swagger doc: #{swagger_checker.swagger_path} does not have"\
           " a documented response code of #{expected_response_code} at path"\
-          " #{method} #{path}"
+          " #{method} #{path}. "\
+          "\n             Available response codes: #{swagger_checker.response_codes_for_path(path, method)}"
       elsif method == "get" && swagger_checker.fragment(path, method, expected_response_code).nil?
         errors << "Swagger doc: #{swagger_checker.swagger_path} missing"\
           " response model for get request with #{path} for code"\


### PR DESCRIPTION
@adamcohen, what do you think of this output format? It's a combination of what I was trying to do with my earlier response output that only worked for response code diffs, and your latest PR. The debug output is attached to the rspec failure output now,

example output:


`rspec spec/data/example_specs.rb` =>

```
API testing scenarios
  unimplemented path
    fails (FAILED - 1)
  mismatched property type
    fails (FAILED - 2)
  unexpected http response
    fails (FAILED - 3)
  extra properties
    fails (FAILED - 4)
    also fails (FAILED - 5)
  missing required
    fails (FAILED - 6)
    also fails (FAILED - 7)
  missing non-required
    passes
    also passes
  fails custom validation
    passes
    fails (FAILED - 8)

Failures:

  1) API testing scenarios unimplemented path fails
     Failure/Error: expect(subject).to validate(:get, "/not_implemented.json", 200)
       Path /not_implemented.json did not respond with expected status code. Expected 200 got 404
     # ./spec/data/example_specs.rb:10:in `block (3 levels) in <top (required)>'

  2) API testing scenarios mismatched property type fails
     Failure/Error: expect(subject).to validate(:get, "/services/{id}.json", 200, { "id" => 1 })
        '/api/services/1.json#/name' of type String did not match one or more of the following types: integer, null  
       Response body:
        {
         "id": 1,
         "name": "hello world"
       }
     # ./spec/data/example_specs.rb:17:in `block (3 levels) in <top (required)>'

  3) API testing scenarios unexpected http response fails
     Failure/Error: expect(subject).to validate(:get, "/services.json", 222)
       Path /services.json did not respond with expected status code. Expected 222 got 200 
       Response body:
        [
         {
           "id": 1,
           "name": "hello world"
         }
       ]
     # ./spec/data/example_specs.rb:25:in `block (3 levels) in <top (required)>'

  4) API testing scenarios extra properties fails
     Failure/Error: expect(subject).to validate(:get, "/services.json", 200)
        '/api/services.json#/0' contains additional properties ["name"] outside of the schema when none are allowed  
       Response body:
        [
         {
           "id": 1,
           "name": "hello world"
         }
       ]
     # ./spec/data/example_specs.rb:33:in `block (3 levels) in <top (required)>'

  5) API testing scenarios extra properties also fails
     Failure/Error: expect(subject).to validate(:get, "/services/{id}.json", 200, { "id" => 1})
        '/api/services/1.json#/' contains additional properties ["name"] outside of the schema when none are allowed  
       Response body:
        {
         "id": 1,
         "name": "hello world"
       }
     # ./spec/data/example_specs.rb:37:in `block (3 levels) in <top (required)>'

  6) API testing scenarios missing required fails
     Failure/Error: expect(subject).to validate(:get, "/services.json", 200)
        '/api/services.json#/0' did not contain a required property of 'test_required'  
       Response body:
        [
         {
           "id": 1,
           "name": "hello world"
         }
       ]
     # ./spec/data/example_specs.rb:45:in `block (3 levels) in <top (required)>'

  7) API testing scenarios missing required also fails
     Failure/Error: expect(subject).to validate(:get, "/services/{id}.json", 200, { "id" => 1})
        '/api/services/1.json#/' did not contain a required property of 'test_required'  
       Response body:
        {
         "id": 1,
         "name": "hello world"
       }
     # ./spec/data/example_specs.rb:49:in `block (3 levels) in <top (required)>'

  8) API testing scenarios fails custom validation fails
     Failure/Error: expect(subject).to conform_to(Apivore::CustomSchemaValidator::WF_SCHEMA)
       The property '#/definitions/service' did not contain a required property of 'type' in schema file:///Users/charles/westfield/apivore/data/custom_schemata/westfield_api_standards.json#
     # ./spec/data/example_specs.rb:72:in `block (3 levels) in <top (required)>'

Finished in 0.14658 seconds (files took 0.98401 seconds to load)
11 examples, 8 failures

Failed examples:

rspec ./spec/data/example_specs.rb:9 # API testing scenarios unimplemented path fails
rspec ./spec/data/example_specs.rb:16 # API testing scenarios mismatched property type fails
rspec ./spec/data/example_specs.rb:24 # API testing scenarios unexpected http response fails
rspec ./spec/data/example_specs.rb:32 # API testing scenarios extra properties fails
rspec ./spec/data/example_specs.rb:36 # API testing scenarios extra properties also fails
rspec ./spec/data/example_specs.rb:44 # API testing scenarios missing required fails
rspec ./spec/data/example_specs.rb:48 # API testing scenarios missing required also fails
rspec ./spec/data/example_specs.rb:71 # API testing scenarios fails custom validation fails```