### PR TITLE
SwaggerChecker falls back to a local load

### DIFF
--- a/spec/swagger_checker_spec.rb
+++ b/spec/swagger_checker_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Apivore::SwaggerChecker do
+  describe '#instance_of' do
+    let(:sample_file_path) { File.join(File.dirname(__FILE__), 'data', '01_sample2.0.json') }
+
+    it 'should be able to load the file via ActionDispatch::Integration' do
+      json = nil
+      open(sample_file_path) { |file| json = file.read }
+      response_double = double('response', body: json)
+      session_double = double('integration', response: response_double, get: 200)
+      allow(ActionDispatch::Integration::Session).to receive(:new).and_return(session_double)
+
+      expect { Apivore::SwaggerChecker.instance_for("/random/url.json") }.to_not raise_error
+    end
+
+    it 'should be able to load the swagger file locally' do
+      expect { Apivore::SwaggerChecker.instance_for(sample_file_path) }.to_not raise_error
+    end
+
+    it 'should throw an exception if it is unable to load the file' do
+      expect { Apivore::SwaggerChecker.instance_for('not_found.json') }.to raise_error(RuntimeError)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #87

I wanted to be able to load the Swagger file without it necessarily being reachable from Rails integration testing, so I added this fallback. A better approach might be to have a pluggable loader that allows the user to specify the loading mechanism. I would love to be able to use Apivore in some command-line scripts that aren't related to testing (ie, generating documentation), so removing an automatic dependence on the Rails environment is a good start.