### PR TITLE
Update to support Rails 5

### DIFF
--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -21,8 +21,8 @@ module Apivore
         send(
           method,
           full_path(swagger_checker),
-          params['_data'] || {},
-          params['_headers'] || {}
+          params: (params['_data'] || {}),
+          headers: (params['_headers'] || {})
         )
         swagger_checker.response = response
         post_checks(swagger_checker)


### PR DESCRIPTION
Tests in rails 5 currently receive this error

```
DEPRECATION WARNING: ActionDispatch::IntegrationTest HTTP request methods will accept only
the following keyword arguments in future Rails versions:
params, headers, env, xhr, as

Examples:

get '/profile',
  params: { id: 1 },
  headers: { 'X-Extra-Header' => '123' },
  env: { 'action_dispatch.custom' => 'custom' },
  xhr: true,
  as: :json
 (called from matches? at /home/vagrant/.rvm/gems/ruby-2.3.1/bundler/gems/apivore-275e799ea72c/lib/apivore/validator.rb:21)
```

Naming the params and headers arguments fixes this.
