### PR TITLE
Fix Rails 5 params deprecation warning

### DIFF
--- a/lib/apivore/rails_shim.rb
+++ b/lib/apivore/rails_shim.rb
@@ -1,0 +1,13 @@
+module Apivore
+  class RailsShim
+    class << self
+      def action_dispatch_request_args(path, params: {}, headers: {})
+        if ActionPack::VERSION::MAJOR >= 5
+          [path, params: params, headers: headers]
+        else
+          [path, params, headers]
+        end
+      end
+    end
+  end
+end

--- a/lib/apivore/validator.rb
+++ b/lib/apivore/validator.rb
@@ -1,5 +1,6 @@
 require 'action_controller'
 require 'action_dispatch'
+require 'apivore/rails_shim'
 
 module Apivore
   class Validator
@@ -20,9 +21,11 @@ module Apivore
       unless has_errors?
         send(
           method,
-          full_path(swagger_checker),
-          params['_data'] || {},
-          params['_headers'] || {}
+          *RailsShim.action_dispatch_request_args(
+            full_path(swagger_checker),
+            params: params['_data'] || {},
+            headers: params['_headers'] || {}
+          )
         )
         swagger_checker.response = response
         post_checks(swagger_checker)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -13,7 +13,7 @@ context "Apivore tests running against a mock API" do
     it 'should show which path and field has the problem' do
       stdout = `rspec spec/data/example_specs.rb --example 'mismatched property type'`
       expect(stdout).to match(/1 failure/)
-      expect(stdout).to include("'/api/services/1.json#/name' of type String did not match one or more of the following types: integer, null")
+      expect(stdout).to include("'/api/services/1.json#/name' of type string did not match one or more of the following types: integer, null")
     end
   end
 

--- a/spec/rails_shim_spec.rb
+++ b/spec/rails_shim_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'Apivore::RailsShim' do
+
+  describe '.action_dispatch_request_args' do
+    subject {
+      Apivore::RailsShim.action_dispatch_request_args(
+        path,
+        params: params,
+        headers: headers
+      )
+    }
+    let(:path) { '/posts' }
+    let(:params) { { 'foo' => 'bar' } }
+    let(:headers) { { 'X-Foo' => 'baz' } }
+
+    before do
+      stub_const('ActionPack::VERSION::MAJOR', actionpack_major_version)
+    end
+
+    context 'using Rails 4' do
+      let(:actionpack_major_version) { 4 }
+
+      it 'returns path, params and headers as positional arguments' do
+        expect(subject).to eq([path, params, headers])
+      end
+    end
+
+    context 'using Rails 5' do
+      let(:actionpack_major_version) { 5 }
+
+      it 'returns path as a positional argument and params and headers as keyword arguments' do
+        expect(subject).to eq([path, { params: params, headers: headers }])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This approach uses a Rails Shim to handle formulating the params for a request to the app in integration tests, as discussed in https://github.com/westfieldlabs/apivore/pull/96#issuecomment-273587222, modeled after https://github.com/thoughtbot/shoulda-matchers/pull/989/files#diff-f46c5b61347eb8f9749762252d06fb52R29 but modified because we have to worry about headers as well (hence the Arrays and splatting).

I briefly considered moving the entire request out to a shimming object, but for whatever reason I couldn't get that to work.  If someone else can, it might be a cleaner approach.  Not sure it's worth driving ourselves crazy over, though.

I had some trouble getting older versions of Ruby to bundle locally for testing, but recent builds seem to work on Travis, so in this case I'm going to rely on Travis to confirm this works for Rails 4.