### PR TITLE
Bump version to 1.6.2

### DIFF
--- a/apivore.gemspec
+++ b/apivore.gemspec
@@ -1,9 +1,9 @@
 $:.push File.expand_path("../lib", __FILE__)
+require 'apivore/version'
 
 Gem::Specification.new do |s|
   s.name        = 'apivore'
-  s.version     = '1.6.1'
-  s.date        = '2016-02-24'
+  s.version     = Apivore::VERSION
   s.summary     = "Tests your API against its OpenAPI (Swagger) 2.0 spec"
   s.description = "Tests your rails API using its OpenAPI (Swagger) description of end-points, models, and query parameters."
   s.authors     = ["Charles Horn"]

--- a/lib/apivore/version.rb
+++ b/lib/apivore/version.rb
@@ -1,3 +1,3 @@
 module Apivore
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
 end

--- a/lib/apivore/version.rb
+++ b/lib/apivore/version.rb
@@ -1,0 +1,3 @@
+module Apivore
+  VERSION = "1.6.1"
+end


### PR DESCRIPTION
- Modify how the version is being set
- Remove extraneous date in gemspec [specification-reference](http://guides.rubygems.org/specification-reference/)
- Bump version for https://github.com/westfieldlabs/apivore/pull/102